### PR TITLE
Fix duplicate notification route

### DIFF
--- a/bhrc_blockchain/api/chain_routes.py
+++ b/bhrc_blockchain/api/chain_routes.py
@@ -166,10 +166,6 @@ def dashboard_data():
 def websocket_test(request: Request):
     return templates.TemplateResponse("notifications_test.html", {"request": request})
 
-@router.get("/notifications/subscribe", response_class=HTMLResponse)
-def websocket_subscriber_ui(request: Request):
-    return templates.TemplateResponse("notifications_subscriber.html", {"request": request})
-
 @router.get("/notifications/subscribe", response_class=HTMLResponse, summary="Kişisel adres bildirim arayüzü")
 def websocket_subscriber_ui(request: Request):
     return templates.TemplateResponse("notifications_subscriber.html", {"request": request})


### PR DESCRIPTION
## Summary
- clean up duplicate `/notifications/subscribe` route

## Testing
- `pytest bhrc_blockchain/tests/api/chain_routes_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841beac78e08328be16990736d1fb8a