### PR TITLE
Remove prints from consensus routes test

### DIFF
--- a/bhrc_blockchain/tests/consensus_routes_test.py
+++ b/bhrc_blockchain/tests/consensus_routes_test.py
@@ -48,16 +48,16 @@ def test_consensus_evaluate_accepts_heavier_chain():
         chain_data.append(d)
 
     # 🔍 Log: Zincir JSON çıktısı
-    print("GÖNDERİLEN ZİNCİR JSON:")
-    print(json.dumps(chain_data, indent=2))
+    # print("GÖNDERİLEN ZİNCİR JSON:")
+    # print(json.dumps(chain_data, indent=2))
 
     # 🧪 API isteği
     response = client.post("/consensus/evaluate", json={"chain": chain_data})
 
     # 🔍 Log: API cevabı
-    print("API RESPONSE:")
-    print(response.status_code)
-    print(response.text)
+    # print("API RESPONSE:")
+    # print(response.status_code)
+    # print(response.text)
 
     # ✅ Beklenen: 200 ve başarılı mesaj
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- comment out leftover prints in `consensus_routes_test.py`

## Testing
- `pytest bhrc_blockchain/tests/consensus_routes_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c050b30883288952a36a82f6c3e2